### PR TITLE
Improving consul registration/health check 

### DIFF
--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>service-gateway-zuul</name>
+	<name>smi-service-gateway</name>
 	<comment></comment>
 	<projects>
 	</projects>
@@ -11,14 +11,13 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.springframework.ide.eclipse.core.springbuilder</name>
+			<name>org.eclipse.buildship.core.gradleprojectbuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.springframework.ide.eclipse.core.springnature</nature>
-		<nature>org.springsource.ide.eclipse.gradle.core.nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
 </projectDescription>

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -7,11 +7,11 @@ gateway:
 spring:
   profiles: default
   application:
-    name: gateway-zuul
+    name: gateway
   cloud:
     consul:
-      #discovery:
-        #prefer-ip-address: true
+      discovery:
+        preferIpAddress: true
       enabled: true
       host: service-registry
       port: 8500


### PR DESCRIPTION
In some environments, consul could have problems resolving a host name, affecting the health check functionality.  Enabling by default the use of IP address resolves this.   Changes include:

-- Setting the default config for the service to prefer the Ip address when doing helth-checks, etc.
-- Changing the application name (used for consul key/value lookup) from gateway-zuul to just gateway
-- Also cleanup unrelated to consul... switching eclipse project file to use buildship